### PR TITLE
#1 Add ISO image parameters to load from URLs and object IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # ACMI x EaaSI game emulator
 
-A centred HTML page that loads an ACMI EaaSI game emulator from its `environment-id`.
+A centred HTML page that loads an ACMI EaaSI game emulator from its `environment-id`, and ISO images from `object-id` or `URL`.
 
 ## Usage
 
 * Find the `environment-id` of the game emulator you'd like to load in the [XOS Work](https://xos.acmi.net.au/admin/collection/work/?q=Emulation+of) field `Eaas environment id` or from the URL of your environment at [playitagain.aarnet.edu.au](https://playitagain.aarnet.edu.au).
 * Visit https://games.acmi.net.au?id=ENVIRONMENT-ID
+* To load an ISO image from an EaaSI object ID, add `isoImageId=ISO-OBJECT-ID` to the URL. e.g. https://games.acmi.net.au?id=ENVIRONMENT-ID&isoImageId=ISO-OBJECT-ID
+* To load an ISO image from a URL, add `isoImageUrl=https://your-image-url.com/image.iso` to the URL. e.g. https://games.acmi.net.au?id=ENVIRONMENT-ID&isoImageUrl=https://your-image-url.com/image.iso
 * The emulator should load centred in the screen
 * If you visit that page without any `id` set you should see the Commodore 64 emulator
 * To change the loading logo, set `eaasEnvironment.innerHTML` to your own HTML in `index.html`

--- a/index.html
+++ b/index.html
@@ -28,6 +28,8 @@
 </head>
 <body>
     <!-- Load the environment-id from the query string ?id=your-environment-id -->
+    <!-- Load the ISO image object-id from the query string ?isoImageId=your-object-id -->
+    <!-- Load the ISO image URL from the query string ?isoImageUrl=https://your-image-url.com/image.iso -->
     <script>
         const body = document.getElementsByTagName('body')[0];
         const params = new Proxy(new URLSearchParams(window.location.search), {
@@ -45,11 +47,25 @@
 
         let environmentId = params.id;
         if (environmentId !== null) {
-            let eaasi = document.getElementsByName('eaas-environment');
             eaasEnvironment.setAttribute('environment-id', environmentId);
         } else {
             // Load the Commodore 64 emulator if no id is present
             eaasEnvironment.setAttribute('environment-id', 'e77b7e3c-9d64-48ee-a7be-ed39e1c8f7bd');
+        }
+
+        let isoImageId = params.isoImageId;
+        if (isoImageId !== null) {
+            let eaasMedium = document.createElement('eaas-medium');
+            eaasMedium.setAttribute('object-id', isoImageId);
+            eaasEnvironment.appendChild(eaasMedium);
+        }
+
+        let isoImageUrl = params.isoImageUrl;
+        if (isoImageUrl !== null) {
+            let eaasMedium = document.createElement('eaas-medium');
+            eaasMedium.setAttribute('type', 'cdrom');
+            eaasMedium.setAttribute('source-url', isoImageUrl);
+            eaasEnvironment.appendChild(eaasMedium);
         }
 
         body.appendChild(eaasEnvironment);


### PR DESCRIPTION
Resolves #1

Let's try loading ISO images on startup using a base OS, rather than having to create one for each ISO.

### Acceptance Criteria
- [x] Add `isoImageUrl` parameter to load a disk image from an S3 bucket
- [x] Add `isoImageId` parameter to load a disk image from an EaaSI Object ID

### Relevant design files
* None

### Testing instructions
1. Try loading an `object-id` via the parameter `isoImageId`: `index.html?id=88dbadb4-8443-4323-8dc5-5e817bd10111&isoImageId=object-id`
1. Try loading a `URL` via the parameter `isoImageUrl`: `index.html?id=88dbadb4-8443-4323-8dc5-5e817bd10111&isoImageUrl=https://your.com/image.iso`